### PR TITLE
Fixed: No history returned if save=false

### DIFF
--- a/src/history.jl
+++ b/src/history.jl
@@ -90,14 +90,14 @@ function update_history!(history::History, estimator::Estimator, tol::Real, elap
     end
 
     # save samples if required
+    if estimator[:save_samples]
+        h[:samples] = samples(estimator)
+        h[:samples_diff] = samples_diff(estimator)
+    end
+
+    push!(history.data, h)
+
     if estimator[:save]
-        if estimator[:save_samples]
-            h[:samples] = samples(estimator)
-            h[:samples_diff] = samples_diff(estimator)
-        end
-
-        push!(history.data, h)
-
         # save history
         save(history)
     end


### PR DESCRIPTION
If the keyword-argument `save=false` is passed to an Estimator at construction time, the estimator will not save the results to disk when it is run. In this case, however, the function also doesn't return the results. This PR fixes this behavior, s.t. the results are returned.